### PR TITLE
feat: extra startSession() extra string support

### DIFF
--- a/lib/src/fancy_logger.dart
+++ b/lib/src/fancy_logger.dart
@@ -96,7 +96,7 @@ class FancyLogger {
   }
 
   /// Increment session id
-  Future<void> startSession() async {
+  Future<void> startSession({String? extra}) async {
     final logStrings = <String>[];
     for (final logger in _loggers) {
       final logString = await logger.sessionStart();
@@ -109,7 +109,9 @@ class FancyLogger {
       '',
       (value, element) => value = '$value$element',
     );
-    _log.fine('Session start $logStringsReduced');
+
+    final extraString = extra == null ? '' : ' $extra';
+    _log.fine('Session start $logStringsReduced$extraString');
   }
 
   /// Get all logs as strings (for debug purposes only)

--- a/test/src/console_logger_test.dart
+++ b/test/src/console_logger_test.dart
@@ -109,4 +109,43 @@ void main() {
     expect(logs[8]['name'], contains('TestLogger'));
     expect(logs[8]['level'], Level.SHOUT.value);
   });
+
+  test('FancyLogger console startSession extra string test', () async {
+    final logs = <Map<String, dynamic>>[];
+
+    void consoleLoggerCallback(
+      String message, {
+      DateTime? time,
+      int? sequenceNumber,
+      int level = 0,
+      String name = '',
+      Zone? zone,
+      Object? error,
+      StackTrace? stackTrace,
+    }) {
+      if (!message.contains('hot-reload')) {
+        logs.add({
+          'message': message,
+          'level': level,
+          'name': name,
+        });
+      }
+    }
+
+    final fancyLogger = FancyLogger();
+    await fancyLogger.init(
+      {},
+      startNewSession: false,
+      dbLogger: false,
+      consoleLoggerCallback: consoleLoggerCallback,
+    );
+
+    await fancyLogger.startSession(extra: 'extra string');
+
+    expect(logs, hasLength(1));
+
+    expect(logs[0]['message'], contains('Session start'));
+    expect(logs[0]['message'], contains('extra string'));
+    expect(logs[0]['name'], contains('FancyLogger'));
+  });
 }

--- a/test/src/db_logger_test.dart
+++ b/test/src/db_logger_test.dart
@@ -108,6 +108,26 @@ void main() {
       expect(logs[8]['logger_name'], 'TestLogger');
     });
 
+    test('add session with extra string', () async {
+      final fancyLogger = FancyLogger();
+      await fancyLogger.init({Level.ALL: 100}, startNewSession: false);
+      await fancyLogger.clearAllLogs();
+
+      await fancyLogger.startSession(extra: 'extra string');
+
+      final logs = await fancyLogger.getAllLogsAsMaps();
+
+      expect(logs, hasLength(1));
+
+      final sessionId = logs[0]['session_id'];
+      expect(logs[0]['level'], Level.FINE.value);
+      expect(
+        logs[0]['message'],
+        'Session start new session id: $sessionId extra string',
+      );
+      expect(logs[0]['logger_name'], 'FancyLogger');
+    });
+
     test('test retain strategy', () async {
       final fancyLogger = FancyLogger();
       await fancyLogger.init(


### PR DESCRIPTION
## Status

**READY**

## Description

Add extra string support for startSession(). It can be app version and build for example.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
